### PR TITLE
A subtle curly brace problem. 

### DIFF
--- a/app/jsx/components/JournalCarouselComp.jsx
+++ b/app/jsx/components/JournalCarouselComp.jsx
@@ -43,7 +43,7 @@ class JournalCarouselComp extends React.Component {
                         imagesLoaded: true,
                         percentPosition: false // px instead of % cells
                       }}>
-        {this.props.data.map( u => {
+        {this.props.data.map( u =>
           <div key={u.unit_id} className="o-itemcarousel__item">
           <Link to={"/uc/" + u.unit_id} className="o-journal2">
             <figure>
@@ -53,7 +53,7 @@ class JournalCarouselComp extends React.Component {
             </figure>
           </Link>
         </div>
-        })}
+        )}
         </CarouselComp>
         <div className="o-stat--item o-itemcarousel__stats-item">
           <Link to={"/" + this.props.campusID + "/journals"}>9,999</Link>Items


### PR DESCRIPTION
ES6 javascript is so crazy with these.

Basically, it was evaluating the body as a series of statements, rather than an expression. So it was making the <div> then throwing it away and returning 'undefined' for every carousel element.

It produces data now. I didn't try debugging any styling issues, thinking that you're more up on that. But if you're tired of carousels and need to trade, lmk.